### PR TITLE
Fix: change basePath (/=>/v1)

### DIFF
--- a/src/main/kotlin/be/zvz/koreanbots/KoreanBots.kt
+++ b/src/main/kotlin/be/zvz/koreanbots/KoreanBots.kt
@@ -28,7 +28,7 @@ import be.zvz.koreanbots.type.mybots.response.Servers as ServersResponse
 
 class KoreanBots(val token: String) {
     init {
-        FuelManager.instance.basePath = "https://api.koreanbots.dev"
+        FuelManager.instance.basePath = "https://api.koreanbots.dev/v1"
     }
 
     fun getBotList(page: Int): BotList {


### PR DESCRIPTION
https://discordapp.com/channels/653083797763522580/653527718561972224/749069576700035162
해당 공지에 따라 추후 해당 요청 base url은 DEPARATED 될 예정이므로
api.koreanbots.dev => api.koreanbots.dev/v1

변경하였습니다.